### PR TITLE
Add ENVI exporters and GUI launcher

### DIFF
--- a/app_main.py
+++ b/app_main.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import threading
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+from envi_reader import f01_parse_envi_header, f02_open_envi_memmap
+from exporters import f03_export_long_feather_streaming, f04_export_excel_spectra_tiled
+
+
+@dataclass
+class AppConfig:
+    header_path: Path
+    output_dir: Path
+    export_feather: bool
+    export_excel: bool
+    chunk_lines: int
+    chunk_bands: int
+    tile_lines: int
+    tile_samples: int
+
+
+def _update_status(state: Dict[str, object], text: str) -> None:
+    root: tk.Tk = state["root"]  # type: ignore[assignment]
+    status_var: tk.StringVar = state["status_var"]  # type: ignore[assignment]
+    root.after(0, status_var.set, text)
+
+
+def f10_select_files(state: Dict[str, object], *, kind: str = "header") -> None:
+    vars_dict: Dict[str, tk.Variable] = state["vars"]  # type: ignore[assignment]
+    if kind == "header":
+        filename = filedialog.askopenfilename(
+            title="Select ENVI header",
+            filetypes=[("ENVI header", "*.hdr"), ("All files", "*.*")],
+        )
+        if not filename:
+            return
+        vars_dict["header_path"].set(filename)
+        if not vars_dict["output_dir"].get():
+            vars_dict["output_dir"].set(str(Path(filename).parent))
+        _update_status(state, "Header selected. Ready to export.")
+    elif kind == "output":
+        folder = filedialog.askdirectory(title="Select output directory")
+        if folder:
+            vars_dict["output_dir"].set(folder)
+            _update_status(state, f"Output directory set to {folder}")
+    else:
+        raise ValueError(f"Unknown selection kind: {kind}")
+
+
+def f11_start_export(state: Dict[str, object]) -> None:
+    worker: Optional[threading.Thread] = state.get("worker")  # type: ignore[assignment]
+    if worker is not None and worker.is_alive():
+        messagebox.showinfo("Export running", "Please wait for the current export to finish.")
+        return
+
+    vars_dict: Dict[str, tk.Variable] = state["vars"]  # type: ignore[assignment]
+    header_path = Path(vars_dict["header_path"].get())  # type: ignore[arg-type]
+    output_dir = Path(vars_dict["output_dir"].get())  # type: ignore[arg-type]
+
+    if not header_path.exists():
+        messagebox.showerror("Missing file", "Please select a valid ENVI header (.hdr) file.")
+        return
+    if not output_dir.exists():
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            messagebox.showerror("Output error", f"Unable to create output directory: {exc}")
+            return
+
+    export_feather = bool(vars_dict["export_feather"].get())
+    export_excel = bool(vars_dict["export_excel"].get())
+
+    if not export_feather and not export_excel:
+        messagebox.showwarning("No export selected", "Please choose at least one export format.")
+        return
+
+    try:
+        chunk_lines = int(vars_dict["chunk_lines"].get())
+        chunk_bands = int(vars_dict["chunk_bands"].get())
+        tile_lines = int(vars_dict["tile_lines"].get())
+        tile_samples = int(vars_dict["tile_samples"].get())
+    except (TypeError, ValueError):
+        messagebox.showerror("Invalid settings", "Chunk and tile sizes must be integers.")
+        return
+
+    config = AppConfig(
+        header_path=header_path,
+        output_dir=output_dir,
+        export_feather=export_feather,
+        export_excel=export_excel,
+        chunk_lines=max(1, chunk_lines),
+        chunk_bands=max(1, chunk_bands),
+        tile_lines=max(1, tile_lines),
+        tile_samples=max(1, tile_samples),
+    )
+
+    thread = threading.Thread(target=_export_one, args=(state, config), daemon=True)
+    state["worker"] = thread
+    _update_status(state, "Starting export...")
+    thread.start()
+
+
+def _export_one(state: Dict[str, object], config: AppConfig) -> None:
+    try:
+        _update_status(state, "Parsing header...")
+        header = f01_parse_envi_header(config.header_path)
+        memmap = f02_open_envi_memmap(config.header_path, header)
+
+        if config.export_feather:
+            feather_path = config.output_dir / f"{config.header_path.stem}.feather"
+            _update_status(state, f"Exporting Feather to {feather_path}...")
+            f03_export_long_feather_streaming(
+                header,
+                memmap,
+                feather_path,
+                chunk_lines=config.chunk_lines,
+                chunk_bands=config.chunk_bands,
+            )
+
+        if config.export_excel:
+            excel_path = config.output_dir / f"{config.header_path.stem}.xlsx"
+            _update_status(state, f"Exporting Excel to {excel_path}...")
+            f04_export_excel_spectra_tiled(
+                header,
+                memmap,
+                excel_path,
+                tile_lines=config.tile_lines,
+                tile_samples=config.tile_samples,
+            )
+
+        _update_status(state, "Export completed successfully.")
+    except Exception as exc:  # pylint: disable=broad-except
+        tb = traceback.format_exc()
+        _update_status(state, f"Export failed: {exc}")
+        root: tk.Tk = state["root"]  # type: ignore[assignment]
+        root.after(
+            0,
+            lambda: messagebox.showerror(
+                "Export failed",
+                f"An error occurred while exporting:\n{exc}\n\nDetails:\n{tb}",
+            ),
+        )
+    finally:
+        root: tk.Tk = state["root"]  # type: ignore[assignment]
+        root.after(0, lambda: state.__setitem__("worker", None))
+
+
+def f12_build_gui(root: tk.Tk) -> Dict[str, object]:
+    root.title("PS SP Analyzer")
+
+    vars_dict: Dict[str, tk.Variable] = {
+        "header_path": tk.StringVar(),
+        "output_dir": tk.StringVar(),
+        "export_feather": tk.BooleanVar(value=True),
+        "export_excel": tk.BooleanVar(value=False),
+        "chunk_lines": tk.IntVar(value=256),
+        "chunk_bands": tk.IntVar(value=16),
+        "tile_lines": tk.IntVar(value=64),
+        "tile_samples": tk.IntVar(value=64),
+    }
+    status_var = tk.StringVar(value="Select an ENVI header to begin.")
+
+    state: Dict[str, object] = {
+        "root": root,
+        "vars": vars_dict,
+        "status_var": status_var,
+        "worker": None,
+    }
+
+    frame = tk.Frame(root, padx=12, pady=12)
+    frame.pack(fill=tk.BOTH, expand=True)
+    frame.columnconfigure(1, weight=1)
+
+    tk.Label(frame, text="ENVI header:").grid(row=0, column=0, sticky="w", pady=2)
+    tk.Entry(frame, textvariable=vars_dict["header_path"]).grid(row=0, column=1, sticky="ew", pady=2)
+    tk.Button(frame, text="Browse...", command=lambda: f10_select_files(state, kind="header")).grid(
+        row=0, column=2, padx=(6, 0), pady=2
+    )
+
+    tk.Label(frame, text="Output directory:").grid(row=1, column=0, sticky="w", pady=2)
+    tk.Entry(frame, textvariable=vars_dict["output_dir"]).grid(row=1, column=1, sticky="ew", pady=2)
+    tk.Button(frame, text="Browse...", command=lambda: f10_select_files(state, kind="output")).grid(
+        row=1, column=2, padx=(6, 0), pady=2
+    )
+
+    tk.Label(frame, text="Feather export:").grid(row=2, column=0, sticky="w", pady=2)
+    tk.Checkbutton(frame, variable=vars_dict["export_feather"]).grid(row=2, column=1, sticky="w", pady=2)
+
+    tk.Label(frame, text="Excel export:").grid(row=3, column=0, sticky="w", pady=2)
+    tk.Checkbutton(frame, variable=vars_dict["export_excel"]).grid(row=3, column=1, sticky="w", pady=2)
+
+    separator = tk.Frame(frame, height=2, bd=1, relief=tk.SUNKEN)
+    separator.grid(row=4, column=0, columnspan=3, sticky="ew", pady=8)
+
+    tk.Label(frame, text="Chunk lines:").grid(row=5, column=0, sticky="w", pady=2)
+    tk.Entry(frame, textvariable=vars_dict["chunk_lines"], width=8).grid(row=5, column=1, sticky="w", pady=2)
+
+    tk.Label(frame, text="Chunk bands:").grid(row=6, column=0, sticky="w", pady=2)
+    tk.Entry(frame, textvariable=vars_dict["chunk_bands"], width=8).grid(row=6, column=1, sticky="w", pady=2)
+
+    tk.Label(frame, text="Tile lines:").grid(row=7, column=0, sticky="w", pady=2)
+    tk.Entry(frame, textvariable=vars_dict["tile_lines"], width=8).grid(row=7, column=1, sticky="w", pady=2)
+
+    tk.Label(frame, text="Tile samples:").grid(row=8, column=0, sticky="w", pady=2)
+    tk.Entry(frame, textvariable=vars_dict["tile_samples"], width=8).grid(row=8, column=1, sticky="w", pady=2)
+
+    tk.Button(frame, text="Start export", command=lambda: f11_start_export(state)).grid(
+        row=9, column=0, columnspan=3, sticky="ew", pady=(12, 4)
+    )
+
+    tk.Label(frame, textvariable=status_var, anchor="w").grid(
+        row=10, column=0, columnspan=3, sticky="ew", pady=(8, 0)
+    )
+
+    return state
+
+
+def f00_safe_run() -> None:
+    root = tk.Tk()
+    state = f12_build_gui(root)
+    try:
+        root.mainloop()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    f00_safe_run()

--- a/envi_reader.py
+++ b/envi_reader.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import numpy as np
+
+
+@dataclass
+class EnviHeader:
+    """Container holding the parsed ENVI header metadata."""
+
+    samples: int
+    lines: int
+    bands: int
+    interleave: str
+    data_type: int
+    byte_order: int
+    header_offset: int = 0
+    file_type: str | None = None
+    data_file: str | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def shape_bsq(self) -> Tuple[int, int, int]:
+        """Return the canonical ``(bands, lines, samples)`` shape."""
+
+        return (self.bands, self.lines, self.samples)
+
+
+def _normalize_key(key: str) -> str:
+    return key.strip().lower().replace(" ", "_")
+
+
+def _parse_value(value: str) -> Any:
+    value = value.strip()
+    if value.startswith("{") and value.endswith("}"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        items = [item.strip() for item in inner.split(",")]
+        parsed = [_parse_value(item) for item in items]
+        return parsed
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    try:
+        if "." in value or "e" in value.lower():
+            return float(value)
+        return int(value)
+    except ValueError:
+        return value
+
+
+def f01_parse_envi_header(path: str | Path) -> EnviHeader:
+    """Parse an ENVI ``.hdr`` file.
+
+    The routine supports simple ``key = value`` pairs as well as multiline
+    ``{ comma, separated, lists }`` sections. All keys are normalised to
+    lowercase snake_case within :attr:`EnviHeader.metadata`.
+    """
+
+    path = Path(path)
+    text = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    if not text:
+        raise ValueError(f"Header file '{path}' is empty")
+    if not text[0].strip().startswith("ENVI"):
+        raise ValueError("ENVI header must start with 'ENVI'")
+
+    metadata: Dict[str, Any] = {}
+    key: str | None = None
+    multiline: list[str] | None = None
+
+    for raw in text[1:]:
+        line = raw.strip()
+        if not line:
+            continue
+        if "=" in line and multiline is None:
+            left, right = line.split("=", 1)
+            key = _normalize_key(left)
+            value = right.strip()
+            if value.startswith("{") and not value.endswith("}"):
+                multiline = [value]
+                continue
+            metadata[key] = _parse_value(value)
+            key = None
+        elif multiline is not None:
+            multiline.append(line)
+            if line.endswith("}"):
+                assert key is not None
+                value = "".join(multiline)
+                metadata[key] = _parse_value(value)
+                multiline = None
+                key = None
+        elif key is not None:
+            # Continuation of previous value.
+            metadata[key] = _parse_value(metadata[key] + " " + line)
+        else:
+            raise ValueError(f"Unable to parse line in header: {raw!r}")
+
+    required = ["samples", "lines", "bands", "interleave", "data_type", "byte_order"]
+    missing = [r for r in required if r not in metadata]
+    if missing:
+        raise ValueError(f"Missing required ENVI keys: {missing}")
+
+    header = EnviHeader(
+        samples=int(metadata["samples"]),
+        lines=int(metadata["lines"]),
+        bands=int(metadata["bands"]),
+        interleave=str(metadata["interleave"]).lower(),
+        data_type=int(metadata["data_type"]),
+        byte_order=int(metadata["byte_order"]),
+        header_offset=int(metadata.get("header_offset", 0)),
+        file_type=str(metadata.get("file_type")) if "file_type" in metadata else None,
+        data_file=str(metadata.get("data_file")) if "data_file" in metadata else None,
+        metadata=metadata,
+    )
+    return header
+
+
+def _f02_envi_dtype(data_type: int, byte_order: int) -> np.dtype:
+    mapping = {
+        1: np.uint8,
+        2: np.int16,
+        3: np.int32,
+        4: np.float32,
+        5: np.float64,
+        6: np.complex64,
+        9: np.complex128,
+        12: np.uint16,
+        13: np.uint32,
+        14: np.int64,
+        15: np.uint64,
+    }
+    if data_type not in mapping:
+        raise ValueError(f"Unsupported ENVI data type: {data_type}")
+    dtype = np.dtype(mapping[data_type])
+    if dtype.byteorder not in {"<", ">", "="}:
+        dtype = dtype.newbyteorder("=")
+    endian = "<" if byte_order == 0 else ">"
+    if dtype.byteorder in {"<", ">"}:
+        dtype = dtype.newbyteorder(endian)
+    else:
+        dtype = dtype.newbyteorder(endian)
+    return dtype
+
+
+def f02_open_envi_memmap(path: str | Path, header: EnviHeader) -> np.memmap:
+    """Open the binary image described by ``header`` as a memory-map."""
+
+    path = Path(path)
+    data_file = header.data_file
+    if data_file:
+        data_path = Path(data_file)
+        if not data_path.is_absolute():
+            data_path = path.parent / data_path
+    else:
+        data_path = path.with_suffix("")
+        if not data_path.exists():
+            for suffix in (".img", ".bin", ".dat"):
+                candidate = path.with_suffix(suffix)
+                if candidate.exists():
+                    data_path = candidate
+                    break
+    if not data_path.exists():
+        raise FileNotFoundError(f"Could not locate ENVI data file for '{path}'")
+
+    dtype = _f02_envi_dtype(header.data_type, header.byte_order)
+
+    interleave = header.interleave.lower()
+    if interleave == "bsq":
+        shape = (header.bands, header.lines, header.samples)
+    elif interleave == "bil":
+        shape = (header.lines, header.bands, header.samples)
+    elif interleave == "bip":
+        shape = (header.lines, header.samples, header.bands)
+    else:
+        raise ValueError(f"Unsupported interleave type: {header.interleave}")
+
+    return np.memmap(
+        data_path,
+        dtype=dtype,
+        mode="r",
+        offset=header.header_offset,
+        shape=shape,
+    )
+
+
+__all__ = [
+    "EnviHeader",
+    "f01_parse_envi_header",
+    "f02_open_envi_memmap",
+]

--- a/exporters.py
+++ b/exporters.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.feather as feather
+
+from envi_reader import EnviHeader
+
+
+def _pa_type_from_numpy(dtype: np.dtype) -> pa.DataType:
+    dtype = np.dtype(dtype)
+    if dtype.kind == "b":
+        return pa.bool_()
+    if dtype.kind == "u":
+        mapping = {
+            1: pa.uint8(),
+            2: pa.uint16(),
+            4: pa.uint32(),
+            8: pa.uint64(),
+        }
+        if dtype.itemsize not in mapping:
+            raise ValueError(f"Unsupported unsigned integer width: {dtype}")
+        return mapping[dtype.itemsize]
+    if dtype.kind == "i":
+        mapping = {
+            1: pa.int8(),
+            2: pa.int16(),
+            4: pa.int32(),
+            8: pa.int64(),
+        }
+        if dtype.itemsize not in mapping:
+            raise ValueError(f"Unsupported signed integer width: {dtype}")
+        return mapping[dtype.itemsize]
+    if dtype.kind == "f":
+        mapping = {
+            2: pa.float16(),
+            4: pa.float32(),
+            8: pa.float64(),
+        }
+        if dtype.itemsize not in mapping:
+            raise ValueError(f"Unsupported float width: {dtype}")
+        return mapping[dtype.itemsize]
+    raise ValueError(f"Unsupported dtype for Arrow conversion: {dtype}")
+
+
+def _read_chunk_band(
+    memmap: np.memmap,
+    header: EnviHeader,
+    line_slice: Tuple[int, int],
+    band_slice: Tuple[int, int],
+) -> np.ndarray:
+    line_start, line_end = line_slice
+    band_start, band_end = band_slice
+    interleave = header.interleave.lower()
+    if interleave == "bsq":
+        data = memmap[band_start:band_end, line_start:line_end, :]
+    elif interleave == "bil":
+        data = np.transpose(memmap[line_start:line_end, band_start:band_end, :], (1, 0, 2))
+    elif interleave == "bip":
+        data = np.transpose(memmap[line_start:line_end, :, band_start:band_end], (2, 0, 1))
+    else:
+        raise ValueError(f"Unsupported interleave: {header.interleave}")
+    return np.asarray(data)
+
+
+def f03_export_long_feather_streaming(
+    header: EnviHeader,
+    memmap: np.memmap,
+    output_path: str | Path,
+    *,
+    chunk_lines: int = 256,
+    chunk_bands: int = 16,
+) -> None:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    line_count = header.lines
+    sample_count = header.samples
+    band_count = header.bands
+
+    value_dtype = np.dtype(memmap.dtype).newbyteorder("=")
+    value_type = _pa_type_from_numpy(value_dtype)
+
+    schema = pa.schema(
+        [
+            pa.field("line", pa.int32()),
+            pa.field("sample", pa.int32()),
+            pa.field("band", pa.int32()),
+            pa.field("value", value_type),
+        ]
+    )
+
+    with feather.FeatherWriter(str(output_path)) as writer:
+        if hasattr(writer, "write_metadata"):
+            writer.write_metadata(schema)
+        for line_start in range(0, line_count, chunk_lines):
+            line_end = min(line_count, line_start + chunk_lines)
+            base_lines = np.arange(line_start, line_end, dtype=np.int32)
+            repeated_lines = np.repeat(base_lines, sample_count)
+            base_samples = np.arange(sample_count, dtype=np.int32)
+            repeated_samples = np.tile(base_samples, line_end - line_start)
+            pa_lines = pa.array(repeated_lines)
+            pa_samples = pa.array(repeated_samples)
+
+            for band_start in range(0, band_count, chunk_bands):
+                band_end = min(band_count, band_start + chunk_bands)
+                chunk = _read_chunk_band(
+                    memmap,
+                    header,
+                    (line_start, line_end),
+                    (band_start, band_end),
+                )
+                for offset, band_index in enumerate(range(band_start, band_end)):
+                    values = np.asarray(chunk[offset], dtype=value_dtype).reshape(-1)
+                    pa_band = pa.array(np.full(values.size, band_index, dtype=np.int32))
+                    pa_values = pa.array(values, type=value_type)
+                    batch = pa.record_batch(
+                        [pa_lines, pa_samples, pa_band, pa_values],
+                        schema=schema,
+                    )
+                    writer.write_batches([batch])
+
+
+def _read_tile_band(
+    memmap: np.memmap,
+    header: EnviHeader,
+    line_slice: Tuple[int, int],
+    sample_slice: Tuple[int, int],
+) -> np.ndarray:
+    line_start, line_end = line_slice
+    sample_start, sample_end = sample_slice
+    interleave = header.interleave.lower()
+    if interleave == "bsq":
+        data = memmap[:, line_start:line_end, sample_start:sample_end]
+        data = np.moveaxis(data, 0, -1)
+    elif interleave == "bil":
+        data = memmap[line_start:line_end, :, sample_start:sample_end]
+        data = np.transpose(data, (0, 2, 1))
+    elif interleave == "bip":
+        data = memmap[line_start:line_end, sample_start:sample_end, :]
+    else:
+        raise ValueError(f"Unsupported interleave: {header.interleave}")
+    return np.asarray(data)
+
+
+def f04_export_excel_spectra_tiled(
+    header: EnviHeader,
+    memmap: np.memmap,
+    output_path: str | Path,
+    *,
+    tile_lines: int = 64,
+    tile_samples: int = 64,
+) -> None:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    value_dtype = np.dtype(memmap.dtype).newbyteorder("=")
+
+    with pd.ExcelWriter(output_path, engine="xlsxwriter") as writer:
+        for line_start in range(0, header.lines, tile_lines):
+            line_end = min(header.lines, line_start + tile_lines)
+            for sample_start in range(0, header.samples, tile_samples):
+                sample_end = min(header.samples, sample_start + tile_samples)
+                tile = _read_tile_band(
+                    memmap,
+                    header,
+                    (line_start, line_end),
+                    (sample_start, sample_end),
+                )
+                tile = np.asarray(tile, dtype=value_dtype)
+                lines = np.arange(line_start, line_end, dtype=np.int32)
+                samples = np.arange(sample_start, sample_end, dtype=np.int32)
+                line_indices = np.repeat(lines, samples.size)
+                sample_indices = np.tile(samples, lines.size)
+                spectra = tile.reshape(lines.size * samples.size, header.bands)
+                columns = [f"band_{idx}" for idx in range(header.bands)]
+                df = pd.DataFrame(spectra, columns=columns)
+                df.insert(0, "sample", sample_indices)
+                df.insert(0, "line", line_indices)
+                sheet_name = f"R{line_start}_C{sample_start}"
+                sheet_name = sheet_name[:31]
+                df.to_excel(writer, sheet_name=sheet_name, index=False)
+
+
+__all__ = [
+    "f03_export_long_feather_streaming",
+    "f04_export_excel_spectra_tiled",
+    "_read_chunk_band",
+    "_read_tile_band",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+pandas
+pyarrow
+openpyxl
+xlsxwriter

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Change to the directory of this script
+pushd "%~dp0"
+
+set "VENV_DIR=.venv"
+if not exist "%VENV_DIR%\Scripts\python.exe" (
+    echo Creating virtual environment in %VENV_DIR%
+    python -m venv "%VENV_DIR%"
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+if errorlevel 1 goto :end
+
+python -m pip install --upgrade pip
+if exist requirements.txt (
+    python -m pip install -r requirements.txt
+)
+
+python app_main.py
+
+:end
+popd
+endlocal


### PR DESCRIPTION
## Summary
- add a Tkinter GUI that wires together ENVI file selection and export workflows
- implement ENVI header parsing and memory-mapped access helpers
- provide streaming Feather and tiled Excel exporters plus supporting scripts and dependencies

## Testing
- python -m compileall app_main.py envi_reader.py exporters.py

------
https://chatgpt.com/codex/tasks/task_b_68da2e3417b0832f86c372521f1734a0